### PR TITLE
#159-frontend-component-display

### DIFF
--- a/ml-covid19-frontend/src/App.tsx
+++ b/ml-covid19-frontend/src/App.tsx
@@ -6,8 +6,6 @@ import Home from "./components/pages/Home";
 import Data from "./components/pages/Data";
 import DetailedData from "./components/pages/DetailedData";
 import Information from "./components/pages/Information";
-import Footer from "./components/footer/Footer";
-
 
 function App() {
     return (
@@ -22,7 +20,6 @@ function App() {
                         <Route path="/information"  component={Information}/>
                     </Switch>
                 </div>
-                <Footer />
             </div>
         </BrowserRouter>
     );

--- a/ml-covid19-frontend/src/components/CovidChart.tsx
+++ b/ml-covid19-frontend/src/components/CovidChart.tsx
@@ -25,7 +25,7 @@ const CovidChart = (props: CovidChartType) => {
     return (
         <div className={props.isReverse ? "covid-chart covid-chart-reverse" : "covid-chart"}>
             <div className="filter-card">
-                <div className="card-title">
+                <div className="covid-chart-card-title">
                     {props.title}
                 </div>
                 <div className="data-number">

--- a/ml-covid19-frontend/src/components/DatePicker.tsx
+++ b/ml-covid19-frontend/src/components/DatePicker.tsx
@@ -46,7 +46,7 @@ const DatePicker = (props: DatePickerPropsType) => {
     }
 
     return (
-        <div className="date-picker">
+        <div>
             <DateRangePicker
                 startDate={startDate}
                 startDateId="start_date_id"

--- a/ml-covid19-frontend/src/components/covidChart.scss
+++ b/ml-covid19-frontend/src/components/covidChart.scss
@@ -29,7 +29,7 @@
   text-align: center;
 }
 
-.card-title {
+.covid-chart-card-title {
   display: flex;
   justify-content: center;
   align-items: center;

--- a/ml-covid19-frontend/src/components/pages/Data.tsx
+++ b/ml-covid19-frontend/src/components/pages/Data.tsx
@@ -2,6 +2,7 @@ import React, {useEffect} from "react";
 import {useActions} from "../../hooks/useActions";
 import {linkData} from "../../store/reducers/navbarReducer";
 import "./data.scss"
+import Footer from "../footer/Footer";
 
 const Data: React.FC = () => {
     const {setPage} = useActions()
@@ -10,7 +11,7 @@ const Data: React.FC = () => {
         setPage(linkData.id)
     }, [])
 
-    return(
+    return (
         <div className="background-data">
             <div className="data">
                 <div className="content-wrapper-data">
@@ -51,6 +52,7 @@ const Data: React.FC = () => {
                     </div>
                 </div>
             </div>
+            <Footer/>
         </div>
     )
 }

--- a/ml-covid19-frontend/src/components/pages/DetailedData.tsx
+++ b/ml-covid19-frontend/src/components/pages/DetailedData.tsx
@@ -5,6 +5,7 @@ import "./detailedData.scss"
 import CovidChart from "../CovidChart"
 import {useTypedSelector} from "../../hooks/useTypedSelector"
 import moment from "moment";
+import Footer from "../footer/Footer"
 
 const DetailedData: React.FC = () => {
     const {
@@ -36,8 +37,8 @@ const DetailedData: React.FC = () => {
     }, [])
 
     return (
-        <div className="detailed-data">
-            <div className="background">
+        <div className="background">
+            <div className="detailed-data">
                 <div className="content-wrapper">
                     <div className="main-heading">Ситуация с Covid-19</div>
                     <CovidChart title="Выявлено случаев"
@@ -60,6 +61,7 @@ const DetailedData: React.FC = () => {
                     />
                 </div>
             </div>
+            <Footer/>
         </div>
     )
 }

--- a/ml-covid19-frontend/src/components/pages/Information.tsx
+++ b/ml-covid19-frontend/src/components/pages/Information.tsx
@@ -2,6 +2,7 @@ import React, {useEffect} from "react";
 import {useActions} from "../../hooks/useActions";
 import {linkInformation} from "../../store/reducers/navbarReducer";
 import "./information.scss"
+import Footer from "../footer/Footer";
 
 const Information: React.FC = () => {
     const {setPage} = useActions()
@@ -104,6 +105,7 @@ const Information: React.FC = () => {
                     </div>
                 </div>
             </div>
+            <Footer/>
         </div>
     )
 }

--- a/ml-covid19-frontend/src/components/pages/data.scss
+++ b/ml-covid19-frontend/src/components/pages/data.scss
@@ -1,5 +1,6 @@
 .data {
   height: 100%;
+  min-height: 100vh;
   width: 100%;
 }
 
@@ -15,15 +16,13 @@
   top: 0;
   left: 0;
   right: 0;
-  padding-bottom: 5%;
 }
 
 .content-wrapper-data {
-  //background-color: aqua;
   padding-top: 80px;
   margin-left: 10%;
   margin-right: 15%;
-
+  padding-bottom: 2%;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -32,7 +31,6 @@
 }
 
 .content-row {
-  //background-color: #E69685;
   width: 100%;
   display: flex;
   flex-wrap: wrap;

--- a/ml-covid19-frontend/src/components/pages/detailedData.scss
+++ b/ml-covid19-frontend/src/components/pages/detailedData.scss
@@ -1,5 +1,6 @@
 .detailed-data {
   height: 100%;
+  min-height: 100vh;
   width: 100%;
 }
 

--- a/ml-covid19-frontend/src/components/pages/home.scss
+++ b/ml-covid19-frontend/src/components/pages/home.scss
@@ -15,14 +15,13 @@
   top: 0;
   left: 0;
   right: 0;
-  padding-bottom: 5%;
 }
 
 .content-wrapper-home {
   padding-top: 80px;
   margin-left: 5%;
   margin-right: 5%;
-
+  padding-bottom: 2%;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -38,8 +37,8 @@
   font-weight: 700;
   font-size: 65px;
   color: #161717;
-  margin-top: 9.9%; //170 px
-  margin-left: 6%; //150px
+  padding-top: 9.9%; //170 px
+  padding-left: 6%; //150px
 }
 
 .sub-heading-home {
@@ -50,7 +49,7 @@
   font-weight: normal;
   font-size: 32px;
   color: #161717;
-  margin-left: 6%;
+  padding-left: 6%;
 }
 
 .data-button-home {

--- a/ml-covid19-frontend/src/components/pages/information.scss
+++ b/ml-covid19-frontend/src/components/pages/information.scss
@@ -1,5 +1,6 @@
 .information {
   height: 100%;
+  min-height: 100vh;
   width: 100%;
 }
 
@@ -11,13 +12,13 @@
   top: 0;
   left: 0;
   right: 0;
-  padding-bottom: 5%;
 }
 
 .content-wrapper-info {
   padding-top: 50px;
   margin-left: 5%;
   margin-right: 5%;
+  padding-bottom: 2%;
   display: flex;
   flex-direction: row;
   justify-content: space-around;
@@ -216,7 +217,6 @@
 .info-line-content {
   margin-top: 20px;
   margin-left: 20px;
-
   display: flex;
   flex-direction: row;
   justify-content: flex-start;


### PR DESCRIPTION
- Исправил отображение `Footer`, теперь он корректно отображается на всех страницах, кроме страницы `home`, где он отсутствует.
- Исправил неверный размер шрифта заголовков в компоненте `CovidChart` 

_Других дефектов отображения компонентов не обнаружил_